### PR TITLE
Add support of non '.js' main

### DIFF
--- a/lib/package.js
+++ b/lib/package.js
@@ -745,6 +745,7 @@ exports.createMain = function(pkg, pjson, downloadDir) {
   var mainPath;
   var pluginMain;
 
+  var mainFileExtension = '.js';
   return Promise.resolve()
 
   // create the main entry point
@@ -762,29 +763,37 @@ exports.createMain = function(pkg, pjson, downloadDir) {
     if (main) {
       if (main.startsWith('./'))
         main = main.substr(2);
-      if (main.endsWith('.js'))
-        main = main.substr(0, main.length - 3);
-    }
 
-    main = main || 'index';
+      var match = /(\.[^.]+)$/.exec(main);
+      if (match) {
+        mainFileExtension = match[1];
+        main = main.slice(0, - mainFileExtension.length);
+      }
+    }
+    else {
+      main = 'index';
+    }
 
     // try the package.json main
     return new Promise(function(resolve) {
-      mainPath = path.resolve(downloadDir, main + '.js');
+      mainPath = path.resolve(downloadDir, main + mainFileExtension);
       fs.exists(mainPath, resolve);
     });
   })
   .then(function(exists) {
     if (exists)
       return exists;
-
+    
     main = lastNamePart;
 
-    if (main.endsWith('.js'))
-      main = main.substr(0, main.length - 3);
+    var match = /(\.[^.]+)$/.exec(main);
+    if (match) {
+      mainFileExtension = match[1];
+      main = main.slice(0, - mainFileExtension.length);
+    }
 
     return new Promise(function(resolve) {
-      mainPath = path.resolve(downloadDir, main + '.js');
+      mainPath = path.resolve(downloadDir, main + mainFileExtension);
       fs.exists(mainPath, resolve);
     });
   })


### PR DESCRIPTION
One custom step need is to add `packages: { "myModule": { defaultExtension: "{myExtension, e.g. ts}" } }`, which is ok to do before 0.17
